### PR TITLE
chore(security): bump Docker base images to node:24-alpine to address bundled npm CVEs

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine AS base
+FROM node:24-alpine AS base
 WORKDIR /app
 COPY package.json /tmp/package.json
 RUN corepack enable && \
@@ -34,7 +34,7 @@ COPY --from=builder /app ./
 RUN pnpm --filter fintrack-api deploy --prod /deploy
 
 # ── runner ────────────────────────────────────────────────────────────────────
-FROM node:22-alpine AS runner
+FROM node:24-alpine AS runner
 WORKDIR /app
 
 ENV NODE_ENV=production

--- a/apps/bot/Dockerfile
+++ b/apps/bot/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine AS base
+FROM node:24-alpine AS base
 WORKDIR /app
 COPY package.json /tmp/package.json
 RUN corepack enable && \
@@ -31,7 +31,7 @@ COPY --from=builder /app ./
 RUN pnpm --filter fintrack-bot deploy --prod /deploy
 
 # ── runner ────────────────────────────────────────────────────────────────────
-FROM node:22-alpine AS runner
+FROM node:24-alpine AS runner
 WORKDIR /app
 
 ENV NODE_ENV=production

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine AS base
+FROM node:24-alpine AS base
 WORKDIR /app
 COPY package.json /tmp/package.json
 RUN corepack enable && \
@@ -31,7 +31,7 @@ RUN pnpm --filter @fintrack/types build
 RUN pnpm --filter fintrack-web build
 
 # ── runner ────────────────────────────────────────────────────────────────────
-FROM node:22-alpine AS runner
+FROM node:24-alpine AS runner
 WORKDIR /app
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1

--- a/scripts/Dockerfile.runner
+++ b/scripts/Dockerfile.runner
@@ -1,4 +1,4 @@
-FROM node:22-alpine
+FROM node:24-alpine
 COPY package.json /tmp/package.json
 RUN corepack enable && \
     PNPM_VERSION=$(node -e "process.stdout.write(require('/tmp/package.json').packageManager.split('@')[1])") && \


### PR DESCRIPTION
## Description

Updated Docker base images from `node:22-alpine` to `node:24-alpine` across API, Web, Bot, and runner images.

This targets Trivy findings reported from bundled npm dependencies inside the image (`/usr/local/lib/node_modules/npm/node_modules/...`), not from project `pnpm-lock.yaml`.

Closes #61 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)

## How Has This Been Tested?

Executed image build validation with project tooling:
- `bash dx pbuild`

- [ ] Unit tests (Jest/Vitest)
- [ ] Integration tests
- [x] Manual testing (screenshots/screencasts encouraged)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented non-obvious behavior or constraints where necessary
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] (If API) Database migrations have been created and tested
- [ ] (If UI) Changes look good on mobile and desktop
