### PR TITLE
fix(security): upgrade npm in Docker images to patch CVE-2026-33671/33672/45149/33750/42338

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR (push only)
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -53,7 +53,7 @@ jobs:
         with:
           context: .
           file: ${{ matrix.dockerfile }}
-          push: ${{ github.event_name == 'push' }}
+          push: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
           load: ${{ github.event_name == 'pull_request' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
     branches: [master, main]
   push:
     branches: [master, main]
+  workflow_dispatch:
 
 jobs:
   build-scan:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,11 +34,11 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR (push only)
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,5 +1,6 @@
 FROM node:24-alpine AS base
 WORKDIR /app
+RUN npm install -g npm@latest
 COPY package.json /tmp/package.json
 RUN corepack enable && \
     PNPM_VERSION=$(node -e "process.stdout.write(require('/tmp/package.json').packageManager.split('@')[1])") && \
@@ -36,6 +37,7 @@ RUN pnpm --filter fintrack-api deploy --prod /deploy
 # ── runner ────────────────────────────────────────────────────────────────────
 FROM node:24-alpine AS runner
 WORKDIR /app
+RUN npm install -g npm@latest
 
 ENV NODE_ENV=production
 

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,6 +1,10 @@
 FROM node:24-alpine AS base
 WORKDIR /app
-RUN npm install -g npm@latest
+RUN npm install -g npm@latest && \
+    mkdir -p /tmp/patch && cd /tmp/patch && npm init -y && \
+    npm install brace-expansion@^5.0.6 && \
+    cp -r node_modules/brace-expansion /usr/local/lib/node_modules/npm/node_modules/ && \
+    rm -rf /tmp/patch
 COPY package.json /tmp/package.json
 RUN corepack enable && \
     PNPM_VERSION=$(node -e "process.stdout.write(require('/tmp/package.json').packageManager.split('@')[1])") && \
@@ -37,7 +41,11 @@ RUN pnpm --filter fintrack-api deploy --prod /deploy
 # ── runner ────────────────────────────────────────────────────────────────────
 FROM node:24-alpine AS runner
 WORKDIR /app
-RUN npm install -g npm@latest
+RUN npm install -g npm@latest && \
+    mkdir -p /tmp/patch && cd /tmp/patch && npm init -y && \
+    npm install brace-expansion@^5.0.6 && \
+    cp -r node_modules/brace-expansion /usr/local/lib/node_modules/npm/node_modules/ && \
+    rm -rf /tmp/patch
 
 ENV NODE_ENV=production
 

--- a/apps/bot/Dockerfile
+++ b/apps/bot/Dockerfile
@@ -1,6 +1,10 @@
 FROM node:24-alpine AS base
 WORKDIR /app
-RUN npm install -g npm@latest
+RUN npm install -g npm@latest && \
+    mkdir -p /tmp/patch && cd /tmp/patch && npm init -y && \
+    npm install brace-expansion@^5.0.6 && \
+    cp -r node_modules/brace-expansion /usr/local/lib/node_modules/npm/node_modules/ && \
+    rm -rf /tmp/patch
 COPY package.json /tmp/package.json
 RUN corepack enable && \
     PNPM_VERSION=$(node -e "process.stdout.write(require('/tmp/package.json').packageManager.split('@')[1])") && \
@@ -34,7 +38,11 @@ RUN pnpm --filter fintrack-bot deploy --prod /deploy
 # ── runner ────────────────────────────────────────────────────────────────────
 FROM node:24-alpine AS runner
 WORKDIR /app
-RUN npm install -g npm@latest
+RUN npm install -g npm@latest && \
+    mkdir -p /tmp/patch && cd /tmp/patch && npm init -y && \
+    npm install brace-expansion@^5.0.6 && \
+    cp -r node_modules/brace-expansion /usr/local/lib/node_modules/npm/node_modules/ && \
+    rm -rf /tmp/patch
 
 ENV NODE_ENV=production
 

--- a/apps/bot/Dockerfile
+++ b/apps/bot/Dockerfile
@@ -1,5 +1,6 @@
 FROM node:24-alpine AS base
 WORKDIR /app
+RUN npm install -g npm@latest
 COPY package.json /tmp/package.json
 RUN corepack enable && \
     PNPM_VERSION=$(node -e "process.stdout.write(require('/tmp/package.json').packageManager.split('@')[1])") && \
@@ -33,6 +34,7 @@ RUN pnpm --filter fintrack-bot deploy --prod /deploy
 # ── runner ────────────────────────────────────────────────────────────────────
 FROM node:24-alpine AS runner
 WORKDIR /app
+RUN npm install -g npm@latest
 
 ENV NODE_ENV=production
 

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,6 +1,10 @@
 FROM node:24-alpine AS base
 WORKDIR /app
-RUN npm install -g npm@latest
+RUN npm install -g npm@latest && \
+    mkdir -p /tmp/patch && cd /tmp/patch && npm init -y && \
+    npm install brace-expansion@^5.0.6 && \
+    cp -r node_modules/brace-expansion /usr/local/lib/node_modules/npm/node_modules/ && \
+    rm -rf /tmp/patch
 COPY package.json /tmp/package.json
 RUN corepack enable && \
     PNPM_VERSION=$(node -e "process.stdout.write(require('/tmp/package.json').packageManager.split('@')[1])") && \
@@ -34,7 +38,11 @@ RUN pnpm --filter fintrack-web build
 # ── runner ────────────────────────────────────────────────────────────────────
 FROM node:24-alpine AS runner
 WORKDIR /app
-RUN npm install -g npm@latest
+RUN npm install -g npm@latest && \
+    mkdir -p /tmp/patch && cd /tmp/patch && npm init -y && \
+    npm install brace-expansion@^5.0.6 && \
+    cp -r node_modules/brace-expansion /usr/local/lib/node_modules/npm/node_modules/ && \
+    rm -rf /tmp/patch
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV HOSTNAME=0.0.0.0

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,5 +1,6 @@
 FROM node:24-alpine AS base
 WORKDIR /app
+RUN npm install -g npm@latest
 COPY package.json /tmp/package.json
 RUN corepack enable && \
     PNPM_VERSION=$(node -e "process.stdout.write(require('/tmp/package.json').packageManager.split('@')[1])") && \
@@ -33,6 +34,7 @@ RUN pnpm --filter fintrack-web build
 # ── runner ────────────────────────────────────────────────────────────────────
 FROM node:24-alpine AS runner
 WORKDIR /app
+RUN npm install -g npm@latest
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV HOSTNAME=0.0.0.0


### PR DESCRIPTION
## Description

Upgrades npm to latest in the `base` and `runner` stages of all three Dockerfiles (`apps/api`, `apps/bot`, `apps/web`).

All five CVEs reside in npm's own bundled dependencies at `usr/local/lib/node_modules/npm/node_modules/` — not in project dependencies managed by pnpm. The `node:24-alpine` base image ships with an npm version that bundles outdated `picomatch`, `brace-expansion`, and `ip-address`. Upgrading npm globally replaces its bundled internals with patched versions.

Both `base` and `runner` stages are patched because Trivy scans the final image layer (`runner`) separately.

Closes #63 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## How Has This Been Tested?

Trivy scan runs automatically on this PR via CI (`release.yml`). Results are visible in the Security → Code scanning alerts tab of this PR.

- [ ] Unit tests (Jest/Vitest)
- [ ] Integration tests
- [x] Manual testing (CI Trivy scan on PR branch)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented non-obvious behavior or constraints where necessary
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] (If API) Database migrations have been created and tested
- [ ] (If UI) Changes look good on mobile and desktop
