### PR TITLE
fix(ci): unblock dependency audit - patch shell-quote, ignore unreachable uuid advisory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,9 @@ jobs:
         uses: actions/dependency-review-action@v4
         with:
           fail-on-severity: moderate
+          # uuid@8.3.2 via next-auth@4 — unreachable vulnerable path; see
+          # package.json pnpm.auditConfig. Revisit on next-auth v5 upgrade.
+          allow-ghsas: GHSA-w5hq-g745-h8pq
 
   test:
     name: Tests

--- a/package.json
+++ b/package.json
@@ -134,18 +134,10 @@
     "typescript-eslint": "^8.52.0"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "@prisma/engines"
-    ],
-    "overrides": {
-      "@types/express": "4.17.21",
-      "@types/express-serve-static-core": "4.19.0",
-      "next": "^16.2.4",
-      "@prisma/client": "^6.19.3",
-      "prisma": "^6.19.3",
-      "zod": "^4.3.6",
-      "postcss": "^8.5.10",
-      "nodemailer": "^8.0.5"
+    "auditConfig": {
+      "ignoreGhsas": [
+        "GHSA-w5hq-g745-h8pq"
+      ]
     }
   },
   "optionalDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,7 @@ overrides:
   zod: ^4.3.6
   postcss: ^8.5.10
   nodemailer: ^8.0.5
+  shell-quote: ^1.8.4
 
 importers:
 
@@ -5083,8 +5084,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
   side-channel-list@1.0.1:
@@ -8500,7 +8501,7 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       rxjs: 7.8.2
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       supports-color: 8.1.1
       tree-kill: 1.2.2
       yargs: 17.7.2
@@ -11241,7 +11242,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.8.4: {}
 
   side-channel-list@1.0.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,24 @@
 packages:
   - "apps/*"
   - "packages/*"
+
+# Migrated from package.json "pnpm" block: pnpm v10 no longer reads these from
+# package.json and ignores them there (see https://pnpm.io/settings).
+onlyBuiltDependencies:
+  - "@prisma/engines"
+
+overrides:
+  "@types/express": "4.17.21"
+  "@types/express-serve-static-core": "4.19.0"
+  next: "^16.2.4"
+  "@prisma/client": "^6.19.3"
+  prisma: "^6.19.3"
+  zod: "^4.3.6"
+  postcss: "^8.5.10"
+  nodemailer: "^8.0.5"
+  # Security: force patched shell-quote (CVE GHSA-w7jw-789q-3m8p, critical).
+  # Pulled transitively (dev-only) by concurrently@9.2.1, which pins 1.8.3.
+  shell-quote: "^1.8.4"
+
+# Note: pnpm audit reads `auditConfig.ignoreGhsas` from package.json, not from
+# this file, so the uuid (GHSA-w5hq-g745-h8pq) ignore lives there.


### PR DESCRIPTION
## Description

Every open Dependabot PR is currently red on the same single check — the
`Security Audit` job. Two advisories were published after master last ran CI:

- **shell-quote@1.8.3** — GHSA-w7jw-789q-3m8p (**critical**), pulled as a
  dev-only transitive dep by `concurrently@9.2.1`. Fixed for real via a pnpm
  override to `^1.8.4`.
- **uuid@8.3.2** — GHSA-w5hq-g745-h8pq (moderate), transitive prod dep of
  `next-auth@4.24.14` (locked to uuid v8). The vulnerable path (v3/v5/v6 buffer
  bounds) is unreachable through next-auth, so it is ignored via
  `pnpm.auditConfig.ignoreGhsas` + `allow-ghsas` in dependency-review, with a
  note to revisit on the next-auth v5 upgrade.

Bonus fix: pnpm v10 no longer reads `pnpm.overrides` / `onlyBuiltDependencies`
from `package.json` and was **silently ignoring them** — migrated to
`pnpm-workspace.yaml` where they now actually apply.

Merging this unblocks all pending Dependabot PRs (then `@dependabot rebase` on each).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Manual testing: `pnpm audit --audit-level=moderate` exits 0 locally
  (was: 1 critical + 1 moderate); lockfile diff is exactly
  `shell-quote 1.8.3 → 1.8.4`; `pnpm run format:check` passes.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented non-obvious behavior or constraints where necessary
- [ ] My changes generate no new warnings — pnpm prints a cosmetic warning
  about `pnpm.auditConfig` in package.json; the ignore still works (audit
  reads it from there), documented in the commit
- [x] New and existing unit tests pass locally with my changes
