### PR TITLE
chore: cloud deploy pipeline (Vercel web + Render API + bot VM) and env template consolidation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,12 @@
 # FinTrack root — Docker Compose build-arg template.
 # Copy this file to .env and fill in your values.
-# Used by docker compose for build args at image build time (not runtime).
+#
+# This file is ONLY for build-time args baked into images by docker compose
+# (see compose.yaml / compose.dev.yaml). Runtime env lives in apps/*/.env.
+#
+# Where does a new var go?
+#   Baked into an image at build time (NEXT_PUBLIC_*, etc.) → here, REQUIRED below.
+#   Read at runtime by a service → its own apps/<app>/.env.example instead.
 
 # ═════════════════════════════════════════════════════════════
 #  REQUIRED  —  web image won't build correctly without this

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,3 +77,40 @@ jobs:
         with:
           sarif_file: trivy-${{ matrix.image_name }}.sarif
           category: ${{ matrix.image_name }}
+
+  deploy-bot:
+    name: Deploy bot to VM
+    needs: build-scan
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - name: Resolve bot image ref
+        id: img
+        run: echo "image=ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')-bot:latest" >> "$GITHUB_OUTPUT"
+
+      - name: Pull new image and recreate container
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.VM_HOST }}
+          username: ${{ secrets.VM_USER }}
+          key: ${{ secrets.VM_SSH_KEY }}
+          envs: GHCR_USER,GHCR_TOKEN,IMAGE
+          script: |
+            set -e
+            echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
+            docker pull "$IMAGE"
+            docker logout ghcr.io
+            docker rm -f fintrack-bot 2>/dev/null || true
+            docker run -d \
+              --name fintrack-bot \
+              --restart unless-stopped \
+              --env-file ~/bot.env \
+              "$IMAGE"
+            docker image prune -f
+        env:
+          GHCR_USER: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IMAGE: ${{ steps.img.outputs.image }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -175,7 +175,9 @@ pnpm run dev
 | `apps/bot/.env`      | `apps/bot/.env.example`      | Dev + Docker — `TELEGRAM_BOT_TOKEN`; Docker hosts injected by compose     |
 
 Each example file is split into REQUIRED (app won't boot without these) and
-OPTIONAL (safe defaults + feature toggles) blocks — read it for per-variable details.
+OPTIONAL (safe defaults + feature toggles) blocks; `apps/api/.env.example` adds a
+REQUIRED IN PRODUCTION block (localhost defaults that must be overridden before
+deploying) — read each file for per-variable details.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,13 +166,13 @@ pnpm run dev
 
 `bash dx setup` copies all example files automatically. For manual setup:
 
-| File                 | Example                      | Notes                                                                     |
-| -------------------- | ---------------------------- | ------------------------------------------------------------------------- |
-| `.env` (repo root)   | `.env.example`               | Docker Compose build args — `NEXT_PUBLIC_TELEGRAM_BOT_ID`                 |
-| `apps/api/.env`      | `apps/api/.env.example`      | Dev + Docker — secrets; Docker hosts injected by compose                  |
-| `apps/api/.env.test` | `apps/api/.env.test.example` | Tests — `fintrack_test`; Docker hosts rewritten by `scripts/test-env.cjs` |
-| `apps/web/.env`      | `apps/web/.env.example`      | Set `NEXT_PUBLIC_API_URL`, `NEXTAUTH_SECRET`, Google OAuth                |
-| `apps/bot/.env`      | `apps/bot/.env.example`      | Dev + Docker — `TELEGRAM_BOT_TOKEN`; Docker hosts injected by compose     |
+| File                 | Example                      | Notes                                                                                                                                |
+| -------------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `.env` (repo root)   | `.env.example`               | Docker Compose build args — `NEXT_PUBLIC_TELEGRAM_BOT_ID`                                                                            |
+| `apps/api/.env`      | `apps/api/.env.example`      | Dev + Docker — secrets; Docker hosts injected by compose                                                                             |
+| `apps/api/.env.test` | `apps/api/.env.test.example` | Tests — `fintrack_test`; Docker hosts rewritten by `scripts/test-env.cjs`                                                            |
+| `apps/web/.env`      | `apps/web/.env.example`      | Set `NEXT_PUBLIC_API_URL`, `NEXTAUTH_SECRET`, Google OAuth                                                                           |
+| `apps/bot/.env`      | `apps/bot/.env.example`      | Dev + Docker — `TELEGRAM_BOT_TOKEN`; Docker hosts injected by compose. Prod values live on the VM (see README → Bot VM Deploy Setup) |
 
 Each example file is split into REQUIRED (app won't boot without these) and
 OPTIONAL (safe defaults + feature toggles) blocks; `apps/api/.env.example` adds a

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@
 - [Deployment Topology](#deployment-topology)
 - [CI/CD](#cicd)
   - [Auto Migration Secrets (GitHub)](#auto-migration-secrets-github)
+  - [Web Vercel Deploy Setup](#web-vercel-deploy-setup)
+  - [Bot VM Deploy Setup](#bot-vm-deploy-setup)
   - [Docker Images (GHCR)](#docker-images-ghcr)
 - [License](#license)
 
@@ -268,9 +270,13 @@ Production deployment flow:
 - **Vercel** -> `apps/web` (Next.js)
 - **Render** -> `apps/api` (Express + Prisma)
 - **Supabase** -> PostgreSQL
-- **TBD** -> `apps/bot` (Telegram bot — no production host configured yet)
+- **Oracle Cloud VM** -> `apps/bot` (Telegram bot — `VM.Standard.E2.1.Micro`, Docker container)
+
+The web app is deployed to Vercel (root [`vercel.json`](./vercel.json) handles the `/FinTrack` basePath redirects and the NextAuth path rewrite). Project settings and env vars live in the Vercel dashboard, not in the file — see [Web Vercel Deploy Setup](#web-vercel-deploy-setup).
 
 The API is deployed to Render via the [`render.yaml`](./render.yaml) Blueprint (Render → New → Blueprint → select repo). It builds `apps/api/Dockerfile`, auto-deploys on `master`, and health-checks `/api/health`. All secrets are declared `sync: false` — set their values in the Render dashboard (Environment tab), never in the file.
+
+The bot is deployed by the `deploy-bot` job in [`release.yml`](./.github/workflows/release.yml): after images build and scan, it SSHes into the VM, pulls `ghcr.io/fintrack-team/fintrack-bot:latest`, and recreates the `fintrack-bot` container (`--restart unless-stopped`, `--env-file ~/bot.env`). This replaces a Watchtower polling setup with a push-based deploy gated on a green build. One-time VM setup is required — see [Bot VM Deploy Setup](#bot-vm-deploy-setup).
 
 Database migrations are applied automatically from GitHub Actions on pushes to `master` when Prisma schema or migrations change.
 
@@ -297,6 +303,35 @@ GitHub Actions runs the following checks on every pull request and push to `mast
 2. Add secret `SUPABASE_DATABASE_URL` (pooled connection string for app/runtime).
 3. Add secret `SUPABASE_DIRECT_URL` (direct connection string for Prisma Migrate).
 4. Push migration changes to `master` and verify workflow `Prisma Migrate Deploy (master)` in Actions tab.
+
+### Web Vercel Deploy Setup
+
+The web app deploys to Vercel from the repo. Unlike `render.yaml`, Vercel has no committed Blueprint — project settings and secrets live in the dashboard (or `vercel env`), never in `vercel.json` (strict JSON, routing only):
+
+1. **Import the repo** (Vercel → Add New → Project). Set the **Root Directory** to the repo root so the root [`vercel.json`](./vercel.json) is picked up; the build runs the `apps/web` Next.js app via Turborepo.
+2. **Set the env vars** from [`apps/web/.env.example`](./apps/web/.env.example) in the dashboard (Project → Settings → Environment Variables), with production values: point `NEXT_PUBLIC_API_URL` at the deployed Render API, set `NEXT_PUBLIC_SITE_ORIGIN` and `NEXTAUTH_URL` to the deployed web origin (`NEXTAUTH_URL` keeps the `/FinTrack` basePath: `<web-origin>/FinTrack/api/auth`).
+3. **Align the API side**: add the deployed web origin to `CORS_ORIGINS` and set `FRONTEND_URL` in the Render dashboard, or browser requests and OAuth redirects break.
+
+The app is served under the `/FinTrack` basePath (`next.config.ts`); the root `vercel.json` redirects `/` → `/FinTrack` and rewrites the NextAuth path accordingly.
+
+### Bot VM Deploy Setup
+
+One-time provisioning of the Oracle `VM.Standard.E2.1.Micro` instance (x86_64) that runs the bot:
+
+1. **Install Docker** on the VM and confirm the deploy user can run it without `sudo` (`sudo usermod -aG docker $USER`, then re-login).
+2. **Create `~/bot.env`** in the deploy user's home from [`apps/bot/.env.example`](./apps/bot/.env.example), with production values: `API_URL` → deployed Render API, `REDIS_URL` → managed Redis (e.g. Upstash), `NODE_ENV=production` (and the production `TELEGRAM_BOT_TOKEN`).
+3. **Generate an SSH key pair** for CI and add the public key to `~/.ssh/authorized_keys` on the VM.
+4. **Add GitHub Actions secrets** (`Settings` -> `Secrets and variables` -> `Actions`):
+   - `VM_HOST` — VM public IP / hostname.
+   - `VM_USER` — deploy username.
+   - `VM_SSH_KEY` — the private key from step 3.
+5. **Open the Oracle security list / VM firewall** for outbound 443 (GHCR pull, Telegram, API). The bot is long-poll — no inbound port needed.
+
+> The VM pulls the private GHCR image using the workflow's built-in `GITHUB_TOKEN` (auto-generated per run, scoped to `packages: read`, and revoked when the job ends — you neither create nor store it). The deploy script logs out of GHCR immediately after pulling.
+
+After setup, every successful push to `master` recreates `fintrack-bot` automatically. To verify a deploy: `docker ps` and `docker logs --tail 50 fintrack-bot` on the VM.
+
+**Granting operator access.** SSH is keyed per public key — `~/.ssh/authorized_keys` holds one line per operator. To give a team member shell access for logs/ops, have them generate their own key pair (`ssh-keygen -t ed25519`) and send you the **public** half only; append it to `authorized_keys` (`chmod 700 ~/.ssh`, `chmod 600 ~/.ssh/authorized_keys`). Each person uses their own key — never share a private key, and keep the CI deploy key (step 3) separate from personal keys so it can be rotated independently.
 
 ### Docker Images (GHCR)
 

--- a/README.md
+++ b/README.md
@@ -270,6 +270,8 @@ Production deployment flow:
 - **Supabase** -> PostgreSQL
 - **TBD** -> `apps/bot` (Telegram bot — no production host configured yet)
 
+The API is deployed to Render via the [`render.yaml`](./render.yaml) Blueprint (Render → New → Blueprint → select repo). It builds `apps/api/Dockerfile`, auto-deploys on `master`, and health-checks `/api/health`. All secrets are declared `sync: false` — set their values in the Render dashboard (Environment tab), never in the file.
+
 Database migrations are applied automatically from GitHub Actions on pushes to `master` when Prisma schema or migrations change.
 
 ---

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -5,6 +5,8 @@
 #   REQUIRED               every env; app refuses to boot without it
 #   REQUIRED IN PRODUCTION  localhost default works for dev; set a real value before deploy
 #   OPTIONAL               safe default; feature stays off until set
+#
+# Deploying the API? Mirror the vars it needs in render.yaml (sync: false).
 
 # ═════════════════════════════════════════════════════════════
 #  REQUIRED  —  all environments; app refuses to boot without these

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,8 +1,13 @@
 # FinTrack API — environment template.
-# Set everything under REQUIRED; OPTIONAL has safe defaults and feature toggles.
+# Copy to .env and fill in your values.
+#
+# Where does a new var go?
+#   REQUIRED               every env; app refuses to boot without it
+#   REQUIRED IN PRODUCTION  localhost default works for dev; set a real value before deploy
+#   OPTIONAL               safe default; feature stays off until set
 
 # ═════════════════════════════════════════════════════════════
-#  REQUIRED  —  app refuses to boot without these
+#  REQUIRED  —  all environments; app refuses to boot without these
 # ═════════════════════════════════════════════════════════════
 
 # Databases — hosts target local (non-Docker) runs. In Docker they are
@@ -13,13 +18,24 @@ DIRECT_URL="postgresql://fintrack:fintrack@localhost:5432/fintrack?schema=public
 REDIS_URL="redis://localhost:6379"
 
 # Secrets & tokens
-ACCESS_TOKEN_SECRET="your_access_token_secret_here"
-CSRF_SECRET="your_csrf_secret_here"
-API_KEY_ENCRYPTION_SECRET="your_api_key_encryption_secret_here" # any non-empty value (hashed to 32 bytes)
+# node -e "console.log(require('crypto').randomBytes(64).toString('hex'))"
+ACCESS_TOKEN_SECRET="<64-byte-hex>"
+CSRF_SECRET="<64-byte-hex>"
+# node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+API_KEY_ENCRYPTION_SECRET="<32-byte-hex>" # sha256-hashed to 32 bytes internally
 
 # Auth providers
 GOOGLE_CLIENT_ID="your_google_client_id.apps.googleusercontent.com" # must match Google Cloud OAuth client
 TELEGRAM_BOT_TOKEN="123456789:your_telegram_bot_token"              # Telegram Login Widget verification
+
+# ═════════════════════════════════════════════════════════════
+#  REQUIRED IN PRODUCTION  —  localhost defaults; must override before deploying
+# ═════════════════════════════════════════════════════════════
+
+# Set to deployed web URL(s); localhost default blocks all browser requests in prod
+CORS_ORIGINS="http://localhost,http://localhost:5173,http://localhost:8080,http://localhost:8000,http://127.0.0.1:5173"
+# Used for OAuth redirects and cookie domain
+FRONTEND_URL="http://localhost:5173"
 
 # ═════════════════════════════════════════════════════════════
 #  OPTIONAL  —  safe defaults; features stay off until configured
@@ -33,13 +49,12 @@ ENABLE_SWAGGER_IN_PROD="false"  # default: false
 HOST="localhost"
 PORT="8000"
 SWAGGER_SERVER_URL="http://localhost:8000/api"
-CORS_ORIGINS="http://localhost,http://localhost:5173,http://localhost:8080,http://localhost:8000,http://127.0.0.1:5173"
-FRONTEND_URL="http://localhost:5173"
 
 # Auth tuning
 GOOGLE_OAUTH_VERIFY_MODE="verifyIdToken" # verifyIdToken | tokeninfo
 # Link the seeded admin user to your real Telegram ID so the bot
 # authenticates as admin and shows the rich seeded transactions.
+# Find your own ID via @userinfobot on Telegram.
 # SEED_TELEGRAM_LINK_ID="123456789"
 
 # Feature · Audit log (MongoDB) — leave unset to disable.

--- a/apps/api/.env.test.example
+++ b/apps/api/.env.test.example
@@ -1,8 +1,13 @@
 # FinTrack API — test environment template.
-# Set everything under REQUIRED; OPTIONAL has safe defaults and feature toggles.
+# Copy to .env.test and fill in your values.
+#
+# Where does a new var go?
+#   REQUIRED  every env; app refuses to boot without it
+#   OPTIONAL  safe default; feature stays off until set
+# (no "required in production" section — tests never deploy)
 
 # ═════════════════════════════════════════════════════════════
-#  REQUIRED  —  app refuses to boot without these
+#  REQUIRED  —  all environments; app refuses to boot without these
 # ═════════════════════════════════════════════════════════════
 
 # Databases — hosts target local (non-Docker) runs. In Docker they are
@@ -13,9 +18,11 @@ DIRECT_URL="postgresql://fintrack:fintrack@localhost:5432/fintrack_test?schema=p
 REDIS_URL="redis://localhost:6379"
 
 # Secrets & tokens
-ACCESS_TOKEN_SECRET="your_access_token_secret_here"
-CSRF_SECRET="your_csrf_secret_here"
-API_KEY_ENCRYPTION_SECRET="your_api_key_encryption_secret_here" # any non-empty value (hashed to 32 bytes)
+# node -e "console.log(require('crypto').randomBytes(64).toString('hex'))"
+ACCESS_TOKEN_SECRET="<64-byte-hex>"
+CSRF_SECRET="<64-byte-hex>"
+# node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+API_KEY_ENCRYPTION_SECRET="<32-byte-hex>" # sha256-hashed to 32 bytes internally
 
 # Auth providers
 GOOGLE_CLIENT_ID="your_google_client_id.apps.googleusercontent.com" # must match Google Cloud OAuth client
@@ -40,6 +47,7 @@ FRONTEND_URL="http://localhost:5173"
 GOOGLE_OAUTH_VERIFY_MODE="verifyIdToken" # verifyIdToken | tokeninfo
 # Link the seeded admin user to your real Telegram ID so the bot
 # authenticates as admin and shows the rich seeded transactions.
+# Find your own ID via @userinfobot on Telegram.
 # SEED_TELEGRAM_LINK_ID="123456789"
 
 # Feature · Audit log (MongoDB) — leave unset to disable.

--- a/apps/bot/.env.example
+++ b/apps/bot/.env.example
@@ -1,8 +1,15 @@
 # FinTrack Bot — environment template.
-# Set everything under REQUIRED; OPTIONAL has safe defaults.
+# Copy to .env and fill in your values.
+#
+# Where does a new var go?
+#   REQUIRED  every env; bot refuses to boot without it (URL vars: always set,
+#             just a different value per env — local / Docker / prod)
+#   OPTIONAL  safe default; feature stays off until set
+# Adding a var with a localhost default that needs a real value in prod? Add a
+# "REQUIRED IN PRODUCTION" section — see apps/api/.env.example.
 
 # ═════════════════════════════════════════════════════════════
-#  REQUIRED  —  bot refuses to boot without these
+#  REQUIRED  —  all environments; bot refuses to boot without these
 # ═════════════════════════════════════════════════════════════
 
 TELEGRAM_BOT_TOKEN="123456789:your_telegram_bot_token"
@@ -13,7 +20,7 @@ API_URL="http://localhost:8000/api"
 REDIS_URL="redis://localhost:6379"
 
 # ═════════════════════════════════════════════════════════════
-#  OPTIONAL  —  safe defaults
+#  OPTIONAL  —  safe defaults; features stay off until configured
 # ═════════════════════════════════════════════════════════════
 
 NODE_ENV="development" # default: development

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,8 +1,15 @@
 # FinTrack Web — environment template.
-# Set everything under REQUIRED; OPTIONAL has safe defaults.
+# Copy to .env and fill in your values.
+#
+# Where does a new var go?
+#   REQUIRED  every env; app won't work correctly without it (URL vars: always set,
+#             just a different value per env — local / preview / prod)
+#   OPTIONAL  safe default; feature stays off until set
+# Adding a var with a localhost default that needs a real value in prod? Add a
+# "REQUIRED IN PRODUCTION" section — see apps/api/.env.example.
 
 # ═════════════════════════════════════════════════════════════
-#  REQUIRED  —  app won't work correctly without these
+#  REQUIRED  —  all environments; app won't work correctly without these
 # ═════════════════════════════════════════════════════════════
 
 # Public URLs — browser-facing values for local (non-Docker) runs. In Docker
@@ -13,7 +20,8 @@ NEXT_PUBLIC_SITE_ORIGIN="http://localhost:5173"
 
 # Auth (NextAuth)
 NEXTAUTH_URL="http://localhost:5173/FinTrack/api/auth"
-NEXTAUTH_SECRET="your_nextauth_secret_min_32_chars" # min 32 chars
+# node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+NEXTAUTH_SECRET="<32-byte-hex>"
 
 # Auth providers
 GOOGLE_CLIENT_ID="your_google_client_id.apps.googleusercontent.com" # must match Google Cloud OAuth client
@@ -23,7 +31,7 @@ GOOGLE_CLIENT_SECRET="your_google_client_secret"
 NEXT_PUBLIC_TELEGRAM_BOT_ID="your_numeric_bot_id"
 
 # ═════════════════════════════════════════════════════════════
-#  OPTIONAL  —  safe defaults
+#  OPTIONAL  —  safe defaults; features stay off until configured
 # ═════════════════════════════════════════════════════════════
 
 # Runtime

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,80 @@
+# Render Blueprint — FinTrack API
+# Render → New → Blueprint → select repo. Render provisions the service below.
+# All secrets use `sync: false`: enter their values in the Render dashboard
+# (Environment tab), never commit them here.
+services:
+  - type: web
+    name: fintrack-api
+    runtime: docker
+    repo: https://github.com/fintrack-team/FinTrack
+    branch: master
+    region: frankfurt
+    plan: free
+    dockerfilePath: apps/api/Dockerfile
+    dockerContext: .
+    healthCheckPath: /api/health
+    autoDeploy: true
+    envVars:
+      # ── Non-secret config ──────────────────────────────────────────────
+      - key: NODE_ENV
+        value: production
+      - key: ENABLE_SWAGGER_IN_PROD
+        value: "false"
+
+      # ── Databases (external: Supabase / Upstash / Atlas ) ─────────
+      - key: DATABASE_URL
+        sync: false
+      - key: DIRECT_URL
+        sync: false
+      - key: REDIS_URL
+        sync: false
+      - key: MONGO_URL
+        sync: false
+
+      # ── Secrets ────────────────────────────────────────────────────────
+      - key: ACCESS_TOKEN_SECRET
+        sync: false
+      - key: CSRF_SECRET
+        sync: false
+      - key: API_KEY_ENCRYPTION_SECRET
+        sync: false
+      - key: TELEGRAM_BOT_TOKEN
+        sync: false
+      - key: GOOGLE_CLIENT_ID
+        sync: false
+      - key: GROQ_API_KEY_1
+        sync: false
+
+      # ── Frontend / CORS (set to your Vercel URL once web is deployed) ───
+      - key: CORS_ORIGINS
+        sync: false
+      - key: FRONTEND_URL
+        sync: false
+
+      # ── Optional: Stripe donations (leave unset to disable; if enabled,
+      #    SUCCESS_URL/CANCEL_URL are required — their localhost defaults
+      #    break the checkout redirect in production) ───────────────────
+      - key: STRIPE_SECRET_KEY
+        sync: false
+      - key: STRIPE_WEBHOOK_SECRET
+        sync: false
+      - key: STRIPE_DONATION_PRICE_ID
+        sync: false
+      - key: STRIPE_DONATION_SUCCESS_URL
+        sync: false
+      - key: STRIPE_DONATION_CANCEL_URL
+        sync: false
+
+      # ── Optional: SMTP email verification (leave unset to disable) ─────
+      - key: SMTP_HOST
+        sync: false
+      - key: SMTP_PORT
+        sync: false
+      - key: SMTP_USER
+        sync: false
+      - key: SMTP_PASS
+        sync: false
+      - key: SMTP_FROM
+        sync: false
+      - key: EMAIL_VERIFICATION_BASE_URL
+        sync: false


### PR DESCRIPTION
## Description

Adds a reproducible, documented cloud deployment path for all three apps and
aligns the env templates and docs with it.

- **Web (Vercel):** documented in README (Web Vercel Deploy Setup) — no committed
  Blueprint, since Vercel keeps project settings and secrets in the dashboard,
  not in `vercel.json` (strict JSON, routing only). Covers Root Directory,
  dashboard env vars, the `/FinTrack` basePath, and the API-side `CORS_ORIGINS` /
  `FRONTEND_URL` alignment. `vercel.json` itself is unchanged.
- **API (Render):** new `render.yaml` Blueprint provisions `fintrack-api`
  (Docker runtime, `/api/health` check, `autoDeploy: true`). Every secret is
  `sync: false` — values are set in the Render dashboard, never committed.
- **Bot (Oracle VM):** new `deploy-bot` job in `release.yml` runs after the
  image build + Trivy scan, SSHes into the VM (`appleboy/ssh-action`), pulls
  `ghcr.io/fintrack-team/fintrack-bot:latest`, and recreates the `fintrack-bot`
  container (`--restart unless-stopped`, `--env-file ~/bot.env`). A push-based
  deploy gated on a green build, instead of a Watchtower polling setup.
- **Env templates:** consolidated `.env*.example` headers with an explicit
  REQUIRED / REQUIRED IN PRODUCTION / OPTIONAL legend, `randomBytes` generation
  hints for secrets, and a render.yaml mirror note in `apps/api/.env.example`.
  Weak placeholder secrets replaced with format placeholders (`<64-byte-hex>`).
- **Docs:** `README.md` gains a Web Vercel Deploy Setup runbook, the Render
  Blueprint deploy note, and a Bot VM Deploy Setup runbook (Docker install,
  `~/bot.env`, CI deploy key, repo secrets, firewall, per-operator SSH access);
  `CONTRIBUTING.md` cross-references the VM runbook from the env-files table.

New repo secrets required for the bot deploy: `VM_HOST`, `VM_USER`, `VM_SSH_KEY`.

Closes #102

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Refactoring (no functional changes)

## How Has This Been Tested?

- [ ] Unit tests (Jest/Vitest)
- [ ] Integration tests
- [x] Manual testing (screenshots/screencasts encouraged)

- CI `release.yml` build + Trivy scan pass for api/web/bot images.
- `render.yaml` and the `deploy-bot` job were reviewed for correctness; the live
  Render Blueprint deploy and the VM bot deploy are verified post-merge (first
  push to `master` after the secrets are set).
- `.env*.example` files reviewed — no real secrets, placeholders only; ToC
  freshness check passes for README and CONTRIBUTING.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documented non-obvious behavior or constraints where necessary
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] (If API) Database migrations have been created and tested
- [ ] (If UI) Changes look good on mobile and desktop