### PR TITLE
fix(bot): re-exchange tokens on 401 instead of rotating refresh

### DIFF
--- a/apps/bot/src/services/apiClient.ts
+++ b/apps/bot/src/services/apiClient.ts
@@ -9,58 +9,26 @@ import {
 
 const { API_URL } = config;
 
-async function apiFetch(
-  method: string,
-  path: string,
-  telegramId: number,
-  body?: unknown,
-): Promise<Response> {
-  const tokens = await getTokens(telegramId);
+const FETCH_TIMEOUT_MS = 20_000;
 
-  const res = await fetch(`${API_URL}${path}`, {
-    method,
-    headers: {
-      "Content-Type": "application/json",
-      ...(tokens ? { Authorization: `Bearer ${tokens.accessToken}` } : {}),
-    },
-    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
-  });
-
-  if (res.status === 401 && tokens) {
-    const refreshed = await tryRefresh(telegramId, tokens.refreshToken);
-    if (refreshed) {
-      return apiFetch(method, path, telegramId, body);
-    }
+async function timedFetch(url: string, init: RequestInit): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
   }
-
-  return res;
 }
 
-async function tryRefresh(
-  telegramId: number,
-  refreshToken: string,
-): Promise<boolean> {
-  const res = await fetch(`${API_URL}/auth/telegram/refresh`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ refreshToken }),
-  });
-
-  if (!res.ok) {
-    await deleteTokens(telegramId);
-    return false;
-  }
-
-  const data = (await res.json()) as TokenPair;
-  await setTokens(telegramId, data);
-  return true;
-}
-
-export async function authenticateUser(
+// Bot is a trusted service client: instead of rotating refresh tokens (which
+// trips the API's reuse-detection when a response is lost to a cold start), it
+// re-exchanges telegramId + name for a fresh pair on demand.
+async function exchangeTokens(
   telegramId: number,
   name: string,
-): Promise<void> {
-  const res = await fetch(`${API_URL}/auth/telegram/exchange`, {
+): Promise<TokenPair> {
+  const res = await timedFetch(`${API_URL}/auth/telegram/exchange`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
@@ -75,7 +43,46 @@ export async function authenticateUser(
   }
 
   const data = (await res.json()) as TokenPair;
-  await setTokens(telegramId, data);
+  await setTokens(telegramId, data, name);
+  return data;
+}
+
+async function apiFetch(
+  method: string,
+  path: string,
+  telegramId: number,
+  body?: unknown,
+  retried = false,
+): Promise<Response> {
+  const tokens = await getTokens(telegramId);
+
+  const res = await timedFetch(`${API_URL}${path}`, {
+    method,
+    headers: {
+      "Content-Type": "application/json",
+      ...(tokens ? { Authorization: `Bearer ${tokens.accessToken}` } : {}),
+    },
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+  });
+
+  if (res.status === 401 && tokens && !retried) {
+    try {
+      await exchangeTokens(telegramId, tokens.name);
+    } catch {
+      await deleteTokens(telegramId);
+      return res;
+    }
+    return apiFetch(method, path, telegramId, body, true);
+  }
+
+  return res;
+}
+
+export async function authenticateUser(
+  telegramId: number,
+  name: string,
+): Promise<void> {
+  await exchangeTokens(telegramId, name);
 }
 
 export async function isAuthenticated(telegramId: number): Promise<boolean> {

--- a/apps/bot/src/services/tokenStore.ts
+++ b/apps/bot/src/services/tokenStore.ts
@@ -1,23 +1,28 @@
 import { redis } from "../lib/redis.js";
 
 export type TokenPair = { accessToken: string; refreshToken: string };
+export type StoredSession = TokenPair & { name: string };
 
 const key = (telegramId: number) => `bot:session:${telegramId}`;
 
-// 30 days TTL – token pair is refreshed on each use
+// 30 days TTL – tokens are re-exchanged on expiry, name lets us mint a fresh pair
 const TTL_SECONDS = 60 * 60 * 24 * 30;
 
-export async function getTokens(telegramId: number): Promise<TokenPair | null> {
+export async function getTokens(
+  telegramId: number,
+): Promise<StoredSession | null> {
   const raw = await redis.get(key(telegramId));
   if (!raw) return null;
-  return JSON.parse(raw) as TokenPair;
+  return JSON.parse(raw) as StoredSession;
 }
 
 export async function setTokens(
   telegramId: number,
   tokens: TokenPair,
+  name: string,
 ): Promise<void> {
-  await redis.set(key(telegramId), JSON.stringify(tokens), "EX", TTL_SECONDS);
+  const session: StoredSession = { ...tokens, name };
+  await redis.set(key(telegramId), JSON.stringify(session), "EX", TTL_SECONDS);
 }
 
 export async function deleteTokens(telegramId: number): Promise<void> {


### PR DESCRIPTION
## What

Stop the bot from rotating refresh tokens. On a 401 it now re-exchanges `telegramId` + `name` for a fresh token pair (one retry), instead of calling `/auth/telegram/refresh`. Adds a 20s fetch timeout; `tokenStore` now persists `name` alongside the tokens. API unchanged.

## Why

Fixes the intermittent `Failed to load history/summary` flap. Access TTL is 15 min, so the bot refreshed often; the API's refresh does rotation + reuse-detection, and a Render free cold start (30–50s) sometimes lost the refresh response *after* the server already rotated. The bot kept the old refresh token, replayed it, the API read that as token theft and revoked the whole session family → 401 → flap until a re-`exchange`. The bot is a trusted service client (it holds `telegramId` + bot secret), so it can just mint fresh tokens via the already-battle-tested `exchange` endpoint — removing refresh removes the entire failure class.

## Testing

Manual: spam `/history` / `/summary` repeatedly — no more `Failed to load`. n/a automated (no test infra for the bot yet).
