### PR TITLE
fix(bot): single-flight token re-exchange + keep tokens on transient failure

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -17,6 +17,10 @@
 # running app, and by scripts/test-env.cjs for tests.
 DATABASE_URL="postgresql://fintrack:fintrack@localhost:5432/fintrack?schema=public"
 DIRECT_URL="postgresql://fintrack:fintrack@localhost:5432/fintrack?schema=public"
+# In production behind a transaction pooler (e.g. Supabase, port 6543), append
+# ?pgbouncer=true&connection_limit=1 to DATABASE_URL — Prisma must skip prepared
+# statements or pooled requests fail with `prepared statement "sN" does not exist`.
+# Keep DIRECT_URL on a direct connection (port 5432, no flag) for migrations.
 REDIS_URL="redis://localhost:6379"
 
 # Secrets & tokens

--- a/apps/bot/src/services/apiClient.ts
+++ b/apps/bot/src/services/apiClient.ts
@@ -1,7 +1,7 @@
 import { config } from "../config.js";
+import { logger } from "../lib/logger.js";
 import {
   type TokenPair,
-  deleteTokens,
   getTokens,
   hasTokens,
   setTokens,
@@ -47,6 +47,21 @@ async function exchangeTokens(
   return data;
 }
 
+// Dedupe concurrent re-exchanges per user: a burst of 401s would otherwise fire
+// one exchange each and blow the API's exchange rate limit (10 / 15 min).
+const inflightExchange = new Map<number, Promise<TokenPair>>();
+
+function exchangeOnce(telegramId: number, name: string): Promise<TokenPair> {
+  let inflight = inflightExchange.get(telegramId);
+  if (!inflight) {
+    inflight = exchangeTokens(telegramId, name).finally(() => {
+      inflightExchange.delete(telegramId);
+    });
+    inflightExchange.set(telegramId, inflight);
+  }
+  return inflight;
+}
+
 async function apiFetch(
   method: string,
   path: string,
@@ -67,12 +82,16 @@ async function apiFetch(
 
   if (res.status === 401 && tokens && !retried) {
     try {
-      await exchangeTokens(telegramId, tokens.name);
-    } catch {
-      await deleteTokens(telegramId);
+      await exchangeOnce(telegramId, tokens.name);
+    } catch (err) {
+      logger.warn({ err, path }, "token re-exchange failed");
       return res;
     }
     return apiFetch(method, path, telegramId, body, true);
+  }
+
+  if (!res.ok) {
+    logger.warn({ status: res.status, method, path }, "api request failed");
   }
 
   return res;


### PR DESCRIPTION
## What

Harden the bot's auth retry path in `apiClient.ts`:

- **Single-flight re-exchange** — concurrent 401s for the same user now share one `/auth/telegram/exchange` call instead of firing one each.
- **Keep tokens on transient exchange failure** — a failed re-exchange (rate limit, cold start, network) now fails just that one request and keeps the stored tokens, instead of wiping them.
- **Log API failures** — non-ok responses and re-exchange failures are logged with status + path. The bot previously had zero visibility into API errors.

## Why

A burst of commands hitting an expired token fired N concurrent exchanges, which trips the API's exchange rate limit (10 / 15 min) and 401s the whole burst. Wiping tokens on a transient blip then forced a full re-auth cascade, turning one failed request into an outage. And with no logging, a production flap was undiagnosable from the bot side — the added `warn` is exactly what surfaced the real status code (a `500` from a Supabase pooler / Prisma prepared-statement issue, fixed separately via `DATABASE_URL` config).

## Testing

Manual: local bot against the deployed API, spammed `/history` / `/summary` — re-exchange dedup holds and the new log surfaced the underlying error. No automated bot test infra yet (only `history.format` is covered).
